### PR TITLE
Add `eventPrefix` plugin setting to allow a prefix for events to be sent

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -26,6 +26,10 @@ Once you have saved your API Keys, this field will be automatically populated wi
 
 Optional. Select which user groups you would like to limit tracking to. Default is all guests and users.
 
+## Event Prefix
+
+If you'd like to add a prefix to all events. For example, you might like to have the 'Placed Order' event show in Klaviyo as `(CC) Placed Order`. Leave blank for no prefix.
+
 ## Cart URL
 
 The URL to your store's cart.

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -15,4 +15,5 @@ class Settings extends Model
     public $cartUrl = '/shop/cart';
     public $productImageField = 'productImage';
     public $productImageFieldTransformation = 'productThumbnail';
+    public $eventPrefix = '';
 }

--- a/src/services/Api.php
+++ b/src/services/Api.php
@@ -39,9 +39,9 @@ class Api extends Base
         }
 
         // Check if there's a prefix for events
-        $prefix = $this->getSetting('eventPrefix');
+        $eventPrefix = $this->getSetting('eventPrefix');
 
-        if ($prefix) {
+        if ($eventPrefix) {
             $event = $eventPrefix . ' ' . $event;
         }
 

--- a/src/services/Api.php
+++ b/src/services/Api.php
@@ -38,6 +38,13 @@ class Api extends Base
             throw new Exception('You must identify a user by email or ID.');
         }
 
+        // Check if there's a prefix for events
+        $prefix = $this->getSetting('eventPrefix');
+
+        if ($prefix) {
+            $event = $eventPrefix . ' ' . $event;
+        }
+
         $params = array(
             'token' => $this->getSetting('klaviyoSiteId'),
             'event' => $event,

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -114,6 +114,18 @@
   </div>
 </div>
 
+<div class="field" id="eventPrefix-field">
+  <div class="heading">
+    <label for="cartUrl">Event Prefix</label>
+		<p class="instructions">{{ "Add prefix text sent for all events. For example '-Prefix- Placed Order'. Optional." | t }}</p>
+  </div>
+	<div class="input">
+    <input
+      class="text fullwidth" type="text" id="eventPrefix" name="eventPrefix"
+      value="{{ settings.eventPrefix }}">
+	</div>
+</div>
+
 <div class="field" id="cartUrl-field">
   <div class="heading">
     <label for="cartUrl">Cart URL</label>


### PR DESCRIPTION
One of our clients has the need to differentiate between current and new events when migrating platforms. This addition allows you to set a prefix to all events sent by the plugin.