### PR TITLE
Provide settings to opt-in/out of specific event tracking

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -34,24 +34,24 @@ class Plugin extends \craft\base\Plugin
             $event->types[] = \fostercommerce\klaviyoconnect\fields\ListsField::class;
         });
 
-        Event::on(User::class, User::EVENT_AFTER_SAVE, function (Event $event) {
-            if ($settings->trackSaveUser) {
+        if ($settings->trackSaveUser) {
+            Event::on(User::class, User::EVENT_AFTER_SAVE, function (Event $event) {
                 Plugin::getInstance()->track->onSaveUser($event);
-            }
-        });
+            });
+        }
 
         if(Craft::$app->plugins->isPluginEnabled('commerce')) {
-            Event::on(Order::class, Order::EVENT_AFTER_SAVE, function (Event $e) {
-                if ($settings->trackCommerceCartUpdated) {
+            if ($settings->trackCommerceCartUpdated) {
+                Event::on(Order::class, Order::EVENT_AFTER_SAVE, function (Event $e) {
                     Plugin::getInstance()->track->onCartUpdated($e);
-                }
-            });
+                });
+            }
 
-            Event::on(Order::class, Order::EVENT_AFTER_COMPLETE_ORDER, function (Event $e) {
-                if ($settings->trackCommerceOrderCompleted) {
+            if ($settings->trackCommerceOrderCompleted) {
+                Event::on(Order::class, Order::EVENT_AFTER_COMPLETE_ORDER, function (Event $e) {
                     Plugin::getInstance()->track->onOrderCompleted($e);
-                }
-            });
+                });
+            }
         }
 
         Event::on(CraftVariable::class, CraftVariable::EVENT_INIT, function (Event $event) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -27,22 +27,30 @@ class Plugin extends \craft\base\Plugin
             'cart' => \fostercommerce\klaviyoconnect\services\Cart::class,
         ]);
 
+        $settings = $this->getSettings();
+
         Event::on(Fields::class, Fields::EVENT_REGISTER_FIELD_TYPES, function (RegisterComponentTypesEvent $event) {
             $event->types[] = \fostercommerce\klaviyoconnect\fields\ListField::class;
             $event->types[] = \fostercommerce\klaviyoconnect\fields\ListsField::class;
         });
 
         Event::on(User::class, User::EVENT_AFTER_SAVE, function (Event $event) {
-            Plugin::getInstance()->track->onSaveUser($event);
+            if ($settings->trackSaveUser) {
+                Plugin::getInstance()->track->onSaveUser($event);
+            }
         });
 
         if(Craft::$app->plugins->isPluginEnabled('commerce')) {
             Event::on(Order::class, Order::EVENT_AFTER_SAVE, function (Event $e) {
-                Plugin::getInstance()->track->onCartUpdated($e);
+                if ($settings->trackCommerceCartUpdated) {
+                    Plugin::getInstance()->track->onCartUpdated($e);
+                }
             });
 
             Event::on(Order::class, Order::EVENT_AFTER_COMPLETE_ORDER, function (Event $e) {
-                Plugin::getInstance()->track->onOrderCompleted($e);
+                if ($settings->trackCommerceOrderCompleted) {
+                    Plugin::getInstance()->track->onOrderCompleted($e);
+                }
             });
         }
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -16,4 +16,9 @@ class Settings extends Model
     public $productImageField = 'productImage';
     public $productImageFieldTransformation = 'productThumbnail';
     public $eventPrefix = '';
+
+    // Tracking Event Options
+    public $trackSaveUser = true;
+    public $trackCommerceCartUpdated = true;
+    public $trackCommerceOrderCompleted = true;
 }


### PR DESCRIPTION
Added some settings to opt in or out of sending specific events. For instance, we have no use for the `onCartUpdated` metric.

This also leads to my next PR, of adding completed order stuff into a queue, rather than holding up payment. Refer to https://github.com/craftcms/commerce/issues/1063