### PR TITLE
Use queue to send order-tracking to Klaviyo, after order-complete

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -9,6 +9,7 @@ use craft\events\RegisterComponentTypesEvent;
 use craft\services\Fields;
 use craft\events\UserGroupsAssignEvent;
 use craft\web\twig\variables\CraftVariable;
+use fostercommerce\klaviyoconnect\queue\jobs\TrackOrderComplete;
 use fostercommerce\klaviyoconnect\variables\Variable;
 use yii\base\Event;
 
@@ -42,7 +43,10 @@ class Plugin extends \craft\base\Plugin
             });
 
             Event::on(Order::class, Order::EVENT_AFTER_COMPLETE_ORDER, function (Event $e) {
-                Plugin::getInstance()->track->onOrderCompleted($e);
+                Craft::$app->getQueue()->delay(10)->push(new TrackOrderComplete([
+                    'name' => $e->name,
+                    'orderId' => $e->sender->id,
+                ]));
             });
         }
 

--- a/src/queue/jobs/TrackOrderComplete.php
+++ b/src/queue/jobs/TrackOrderComplete.php
@@ -1,0 +1,54 @@
+<?php
+namespace fostercommerce\klaviyoconnect\queue\jobs;
+
+use fostercommerce\klaviyoconnect\Plugin;
+
+use craft\commerce\elements\Order;
+
+use Craft;
+use craft\queue\BaseJob;
+
+use yii\base\Event;
+
+class TrackOrderComplete extends BaseJob
+{
+    // Properties
+    // =========================================================================
+
+    public $name;
+    public $orderId;
+
+
+    // Public Methods
+    // =========================================================================
+
+    public function execute($queue)
+    {
+        $this->setProgress($queue, 1);
+
+        if ($this->orderId) {
+            $order = Order::find()->id($this->orderId)->one();
+
+            if ($order) {
+                // Construct the event and pass like we normally would
+                $event = new Event([
+                    'name' => $this->name,
+                    'sender' => $order,
+                ]);
+
+                Plugin::getInstance()->track->onOrderCompleted($event);
+            }
+        }
+
+        return true;
+    }
+
+
+    // Protected Methods
+    // =========================================================================
+
+    protected function defaultDescription(): string
+    {
+        return 'Sending `Order Complete` event to Klaviyo';
+    }
+}


### PR DESCRIPTION
Pulling this out as separate from https://github.com/FosterCommerce/klaviyoconnect/pull/18, but we would highly recommend removing any blocks or slow-downs in the payment process for best conversion. No one likes a slow checkout.

As such, and following Commerce's lead, we should remove any after-order-complete events into a queue so they're run in the background. As per https://github.com/craftcms/commerce/issues/1063

You'll notice that I'm only sending the ID of the order, not the full order event. This is because it has to store all this data in the queue database table row for the job - which will be massive. Its much better to store the order ID, then fetch it again later.