### PR TITLE
Bugfix: add timestamp to event_id to make it truly unique

### DIFF
--- a/src/services/Track.php
+++ b/src/services/Track.php
@@ -14,6 +14,7 @@ use fostercommerce\klaviyoconnect\events\AddProfilePropertiesEvent;
 use yii\base\Event;
 use Klaviyo;
 use GuzzleHttp\Exception\RequestException;
+use DateTime;
 
 class Track extends Base
 {
@@ -125,8 +126,9 @@ class Track extends Base
 
         if ($profile) {
             $orderDetails = $this->getOrderDetails($order, $eventName);
+            $dateTime = new DateTime();
             $event = [
-                'event_id' => $order->id,
+                'event_id' => $order->id.'_'.$dateTime->getTimestamp(),
                 'value' => $order->getTotalPrice(),
             ];
             $eventProperties = new EventProperties($event);
@@ -147,7 +149,7 @@ class Track extends Base
                 if ($eventName === 'Placed Order') {
                     foreach ($orderDetails['Items'] as $item) {
                         $event = [
-                            'event_id' => $order->id.'_'.$item['Slug'],
+                            'event_id' => $order->id.'_'.$item['Slug'].'_'.$dateTime->getTimestamp(),
                             'value' => $item['RowTotal'],
                         ];
 

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -160,3 +160,17 @@
       value="{{ settings.productImageFieldTransformation }}">
 	</div>
 </div>
+
+{{ forms.checkboxField({
+  label: "Track Commerce Cart Updated",
+  name: 'trackCommerceCartUpdated',
+  checked: settings.trackCommerceCartUpdated,
+  instructions: 'Track in Klaviyo when the cart is updated'
+}) }}
+
+{{ forms.checkboxField({
+  label: "Track Commerce Order Complete",
+  name: 'trackCommerceOrderCompleted',
+  checked: settings.trackCommerceOrderCompleted,
+  instructions: 'Track in Klaviyo when order is completed'
+}) }}


### PR DESCRIPTION
This is breaking events like Add to Cart, etc, because the event_id must be unique, not just the orderId.

Edit: Also added settings for tracking order and cart updates

https://help.klaviyo.com/hc/en-us/articles/115005082927
"The $event_id should be a unique identifier for the cart combined with the UNIX formatted time when the event was triggered."