### PR TITLE
Fix parseEnv error being thrown for some craft versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "fostercommerce/klaviyoconnect",
     "description": "Craft Commerce",
     "type": "craft-plugin",
-    "version": "4.0.14",
+    "version": "4.0.15",
     "keywords": [
       "klaviyo"
     ],

--- a/src/services/Base.php
+++ b/src/services/Base.php
@@ -29,7 +29,11 @@ abstract class Base extends Component
         $value = $this->settings->$name;
 
         if (is_string($value)) {
-            $value = App::parseEnv($value);
+            if (method_exists('App', 'parseEnv')){
+                $value = App::parseEnv($value);
+            } else {
+                $value = Craft::parseEnv($value);
+            }
         }
         
         return $value;


### PR DESCRIPTION
## Notes

- Fix the issue where the method `craft\helpers\App::parseEnv($variable)` throws an error on Craft versions that are before 3.7.29