### PR TITLE
Remove typing on anonymous variable in cart controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for KlaviyoConnect
 
+## 4.0.16.2 2023-06-07
+### Fixed
+- Fixes issue with type declaration on controller for PHP 7
+  
+
 ## 4.0.16.1 2023-04-31
 ### Fixed
 - Fixes issue caused in last update which caused a 500 error when updating an order in the CP

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "fostercommerce/klaviyoconnect",
     "description": "Craft Commerce",
     "type": "craft-plugin",
-    "version": "4.0.16.1",
+    "version": "4.0.16.2",
     "keywords": [
       "klaviyo"
     ],

--- a/src/controllers/CartController.php
+++ b/src/controllers/CartController.php
@@ -10,7 +10,7 @@ use yii\web\Response;
 
 class CartController extends Controller
 {
-    protected array|int|bool $allowAnonymous = true;
+    protected $allowAnonymous = true;
 
     public function actionRestore(): Response
     {


### PR DESCRIPTION
In response to this issue https://github.com/FosterCommerce/klaviyoconnect/issues/113

Removes type declaration on $anonymous variable of cart controller to avoid problem using with PHP 7