### PR TITLE
fix: handle both string JSON and array inputs for ListField

### DIFF
--- a/src/fields/ListField.php
+++ b/src/fields/ListField.php
@@ -47,9 +47,14 @@ class ListField extends Field
 	public function normalizeValue(mixed $value, ?ElementInterface $element = null): mixed
 	{
 		if ($value) {
-			$o = json_decode((string) $value);
-			if ($o) {
-				$value = $o->id;
+			// Handle both string JSON and array inputs
+			if (is_array($value)) {
+				$value = $value['id'] ?? null;
+			} else {
+				$o = json_decode((string) $value);
+				if ($o) {
+					$value = $o->id;
+				}
 			}
 		}
 


### PR DESCRIPTION
## Array to String Conversion Error in ListField.php

When submitting a form with an array value for the Klaviyo List field, the following error occurs

ErrorException: Array to string conversion in ListField.php:50

### Steps to Reproduce
1. Create a Klaviyo List field in Craft
2. Submit form data in a global/entry
3. Error occurs in normalizeValue() when trying to cast array to string

I've submitted a PR that handles both array and string inputs