### PR TITLE
fix: Use correct timestamp value when syncing past orders

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,9 +41,9 @@
   "minimum-stability": "dev",
   "scripts": {
     "phpstan": "phpstan --memory-limit=1G",
-    "ecs-check": "ecs check --ansi --memory-limit=1G",
-    "ecs-fix": "ecs check --ansi --fix --memory-limit=1G",
-    "rector": "rector process",
-    "rector-dry-run": "rector process --dry-run"
+    "ecs:check": "ecs check --ansi --memory-limit=1G",
+    "ecs:fix": "ecs check --ansi --fix --memory-limit=1G",
+    "rector:fix": "rector process",
+    "rector:dry-run": "rector process --dry-run"
   }
 }

--- a/src/queue/jobs/SyncOrders.php
+++ b/src/queue/jobs/SyncOrders.php
@@ -24,7 +24,7 @@ class SyncOrders extends BaseJob
 					'Placed Order',
 					$order,
 					null,
-					(string) $order->dateOrdered?->getTimestamp(),
+					$order->dateOrdered?->format('Y-m-d\TH:i:s'),
 				);
 			}
 		}


### PR DESCRIPTION
Applies the changes in https://github.com/FosterCommerce/klaviyoconnect/pull/136 to the Craft 5 version.