### PR TITLE
fix: Support normalisation of both frontend submission and DB retrieval

### DIFF
--- a/src/fields/ListsField.php
+++ b/src/fields/ListsField.php
@@ -61,7 +61,12 @@ class ListsField extends Field
 
 	public function normalizeValue(mixed $value, ?ElementInterface $element = null): mixed
 	{
-		$value = is_array($value) ? collect($value)->pluck('id')->toArray() : [];
+		if (is_array($value) && is_array(reset($value))) {
+			// DB format
+			$value = array_column($value, 'id');
+		} else {
+			$value = is_array($value) ? $value : [];
+		}
 
 		$modified = [];
 


### PR DESCRIPTION
DB retrieval has format: `[['id' => 'id', 'name' => 'name'], ['id' => 'id', 'name' => 'name']]`.
Frontend submission has format: `['id', 'id']`.

Currently causes issues saving frontend submission, as `pluck` can't find an `id` field and then just returns an empty array.